### PR TITLE
feat: Dockerize application for GCP Cloud Run

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,34 @@
+# Python virtual environment
+venv/
+.venv/
+
+# Python bytecode and cache
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+
+# IDE / Editor specific files
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# Git directory
+.git/
+.gitignore
+
+# Docker files (if they are not meant to be in the image itself, though Dockerfile is usually fine)
+# Dockerfile # Typically you don't ignore the Dockerfile itself
+
+# Other OS generated files
+.DS_Store
+Thumbs.db
+
+# Any local instance of the database if it's generated outside the main store.db
+# For instance, if you had a backup or a test db you didn't want in the image
+# *.local.db 
+
+# Test files or directories if not needed in production image
+# tests/
+# *.test.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+# Use an official Python runtime as a parent image
+FROM python:3.9-slim
+
+# Set environment variables
+ENV PYTHONUNBUFFERED=1
+ENV FLASK_APP=app.py
+# ENV FLASK_ENV=production # Optional: can be set here or in Cloud Run service definition
+# PORT is automatically set by Cloud Run, but can be defaulted here for local Docker runs
+ENV PORT 8080
+# Set FLASK_SECRET_KEY in Cloud Run service environment variables, not here.
+# For local Docker runs, you can pass it with -e FLASK_SECRET_KEY="..."
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Install system dependencies that might be needed by Python packages (if any)
+# For example, if a package needed gcc or other build tools:
+# RUN apt-get update && apt-get install -y --no-install-recommends gcc && rm -rf /var/lib/apt/lists/*
+# For now, our requirements (Flask, pandas, openpyxl, gunicorn) don't seem to need extra system deps.
+
+# Copy the requirements file into the container
+COPY requirements.txt .
+
+# Install Python dependencies
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the rest of the application code into the container
+# This includes app.py, database_setup.py, store.db, and the static/ and templates/ folders
+COPY . .
+
+# Make port 8080 available to the world outside this container
+# (Cloud Run uses the PORT env var, which we've defaulted to 8080)
+EXPOSE 8080
+
+# Define the command to run the application using Gunicorn
+# Gunicorn will listen on the port specified by the PORT environment variable.
+# Number of workers can be adjusted based on expected load and available CPU.
+# For Cloud Run, typically 1 worker with multiple threads is a good starting point.
+# Cloud Run will send SIGTERM for shutdown. Default timeout is 10s.
+CMD exec gunicorn --bind 0.0.0.0:$PORT --workers 1 --threads 4 --timeout 0 app:app

--- a/app.py
+++ b/app.py
@@ -5,7 +5,9 @@ import os # For secret_key
 from datetime import timedelta # For session lifetime
 
 app = Flask(__name__)
-app.secret_key = os.urandom(24) # Configure secret key for sessions
+# For production, FLASK_SECRET_KEY should be a strong, persistent random string.
+# If FLASK_SECRET_KEY is not set, os.urandom(24) is used as a fallback (suitable for dev).
+app.secret_key = os.environ.get('FLASK_SECRET_KEY', os.urandom(24))
 app.permanent_session_lifetime = timedelta(days=7) # Optional: Configure session lifetime
 
 DATABASE_NAME = 'store.db' # Add this line
@@ -617,4 +619,6 @@ if __name__ == '__main__':
     # In a production environment, you'd run database_setup.py separately.
     from database_setup import setup_database
     setup_database()
-    app.run(debug=True)
+    # Development server configuration
+    port = int(os.environ.get('PORT', 5000)) # Use PORT env var if available, else default to 5000
+    app.run(host='0.0.0.0', port=port, debug=True)

--- a/app.py
+++ b/app.py
@@ -621,4 +621,7 @@ if __name__ == '__main__':
     setup_database()
     # Development server configuration
     port = int(os.environ.get('PORT', 5000)) # Use PORT env var if available, else default to 5000
-    app.run(host='0.0.0.0', port=port, debug=True)
+    # Debug mode should be False in production. 
+    # Set FLASK_DEBUG=true in your local environment if you need the debugger.
+    debug_mode = os.environ.get('FLASK_DEBUG', 'False').lower() == 'true'
+    app.run(host='0.0.0.0', port=port, debug=debug_mode)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Flask>=2.0
 openpyxl>=3.0
 pandas>=1.3
 python-dotenv>=0.19
+gunicorn>=20.0


### PR DESCRIPTION
This commit introduces Docker support for the Flask application, enabling containerized deployment, specifically targeting GCP Cloud Run.

Changes include:

1.  **`Dockerfile` Creation:**
    - Added a `Dockerfile` in the project root.
    - Uses `python:3.9-slim` as the base image.
    - Sets environment variables (`PYTHONUNBUFFERED`, `FLASK_APP`, `PORT`).
    - Installs Python dependencies from `requirements.txt`.
    - Copies the application code, including `store.db` as per your request, into the image.
    - Exposes port 8080 (configurable via `PORT` env var).
    - Uses Gunicorn as the WSGI server for running the application. The CMD is `exec gunicorn --bind 0.0.0.0:$PORT --workers 1 --threads 4 --timeout 0 app:app`.

2.  **`.dockerignore` File:**
    - Added a `.dockerignore` file to exclude common unnecessary files (e.g., `venv`, `__pycache__`, `.git`, IDE configs) from the Docker build context, optimizing image size and build time.

3.  **Application Code Updates (`app.py`):**
    - Modified `app.py` to read the `SECRET_KEY` from an environment variable (`FLASK_SECRET_KEY`), with `os.urandom(24)` as a fallback for development if the variable is not set. This is crucial for secure and consistent session management in deployed environments.
    - Updated the `app.run()` command in the `if __name__ == '__main__':` block to use `host='0.0.0.0'` and a port configurable via the `PORT` environment variable (defaulting to 5000). This makes local development server behavior more aligned with container environments.

4.  **Dependencies (`requirements.txt`):**
    - Added `gunicorn` to `requirements.txt` as it's now the designated WSGI server for the Docker container.

These changes prepare the application for building a Docker image suitable for deployment on GCP Cloud Run or other container platforms.