### PR TITLE
fix: Resolve SpooledTemporaryFile seek error in Excel upload

### DIFF
--- a/app.py
+++ b/app.py
@@ -261,6 +261,8 @@ def upload_products_excel():
 
     conn = None # Initialize for finally block
     try:
+        # Ensure the stream pointer is at the beginning
+        file.stream.seek(0) 
         # Try reading the file into a pandas DataFrame
         df = pd.read_excel(file.stream)
     except Exception as e:


### PR DESCRIPTION
Addresses an error where pandas could fail to read an uploaded Excel file stream (SpooledTemporaryFile) due to issues with stream positioning, manifesting as "'SpooledTemporaryFile' object has no attribute 'seekable'" or similar errors.

The fix involves explicitly rewinding the file stream to its beginning using `file.stream.seek(0)` before `pd.read_excel(file.stream)` is called in the `/api/upload_products_excel` route. This ensures that pandas can correctly parse the Excel file, regardless of previous operations on the stream or the specific Excel format being parsed.